### PR TITLE
Change up styles of Homepage

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -340,7 +340,11 @@ header{
 
 /*Topics*/
 #topics{
-  margin-top: 4%;
+  padding-top: 4%;
+}
+
+#topic-wrapper {
+  background: linear-gradient(to bottom right, #fff, #d1aaee)
 }
 .profile-card{
   /* width: 400px; */
@@ -526,19 +530,23 @@ footer{
   width: 7rem;
   height: 7rem;
   background-color: #2a00e3;
-  position: absolute;
+  position: fixed;
   top: -3rem;
-  left: 50%;
+  right: 0;
+  top: 80%; /* for browsers that do not support calc() */
+  top: calc(95% - 7rem);
   transform: translateX(-50%);
   border-radius: 50%;
+  text-align: center;
+  z-index: 1000;
 }
 
 .back-to-top i{
   display: block;
   color: #fff;
   font-size: 2rem;
-  padding: 2rem;
-  animation: up 2s infinite;
+  padding: 3rem 0 2rem 0;
+  animation: up 15s infinite;
 }
 
 .footer-content{
@@ -814,11 +822,15 @@ footer{
   0%{
       opacity: 0;
   }
-  50%{
+  10%{
       opacity: 1;
   }
-  100%{
-      opacity: 0;
-      transform: translateY(-1rem);
+  20%, 80% { 
+      opacity: 1;
+      transform: translateY(-0.5rem);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-1rem);
   }
 } 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -343,21 +343,44 @@ header{
   margin-top: 4%;
 }
 .profile-card{
-  width: 400px;
+  /* width: 400px; */
   text-align: center;
   border-radius: 8px;
   overflow: hidden;
-  margin:20px;
+  /* margin:20px; */
+  margin-top: 20px;
+  margin-bottom: 20px;
 }
 
 
 
 .card-header{
-  padding: 60px 40px;
+  padding: 60px 40px 112px 40px;
   border: 2px solid black;
+  position: relative;
   /*border-radius: 20px;*/
 }
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(2px);
+  padding-top: 60px;
+  transition: .2s;
+  margin-bottom: 48px;
+}
 
+.overlay:hover {
+  background-color: rgba(0, 0, 0, 0);
+  backdrop-filter: blur(0px);
+}
+.overlay:hover .name {
+  transition: .2s;
+  text-shadow: 1px 1px 10px #121212;
+}
 
 #one{
   background:url('../img/aiWallpaper.jpeg');
@@ -410,17 +433,12 @@ header{
   height: 300px;
   border-radius: 50%;
 }
-
 .name{
   color: #f2f2f2;
   font-size: 28px;
   font-weight: 600;
   margin: 10px 0;
-}
-.name:hover {
-  font-size: 30px;
-  transition: .5s;
-  text-shadow: 1px 1px 10px #121212;
+  z-index: 100;
 }
 
 .desc{
@@ -461,7 +479,7 @@ header{
 }
 
 .card-footer{
-  background: #000000;
+  background: #29004d;
   padding: 30px 10px;
   margin-top: 5px;
   /*border-radius: 80px;*/

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
   <link rel='stylesheet' id='customify-font-stylesheet-10-css'  href='//pxgcdn.com/fonts/billy-ohio/stylesheet.css' type='text/css' media='all' />
 </head>
 <body>
+  <div class="back-to-top">
+    <a href="#hero"><i class="fas fa-chevron-up"></i></a>
+</div>
   <header>
     <div class="container">
         <nav class="navb">
@@ -30,7 +33,7 @@
                     <a href="#topics" class="navlink">Topics</a>
                 </li>
                 <li class="navitem">
-                    <a href="#footer" class="navlink">Contac</a>
+                    <a href="#footer" class="navlink">Contact</a>
                 </li>
             </ul>
         </nav>
@@ -58,7 +61,7 @@
 </section>
 <!--Hero ends-->   
 <div class="parallax">
-<div>
+<div id="topic-wrapper">
 <!-- Terms we will use to define categories Beginner Amateur Semi pro Professional Word class-->
 <!--row1-->
 <!--1st box-->
@@ -212,12 +215,30 @@
       </div>
       </div>
     </div>
+    <!-- stray database management topic in the footer, moved up into the topics area. Uncomment if necessary 
+      <div class="profile-card col-lg-4 col-md-6 col-sm-12">
+          <a href="https://www.db-book.com/db4/slide-dir/ch1-2.pdf">
+              <div class="card-header" style="background:url(images/databasemgmnt.png) no-repeat center;object-fit: cover;">
+                  <div class="name">Database Management</div>
+              </div>
+          </a>
+          <div class="card-footer">
+            <div class="numbers">
+                <div class="item">
+                    <span>11</span> Course Length
+                </div>
+                <div class="border"></div>
+                <div class="item">
+                    <span>Beginner</span> Level
+                </div>
+            </div>
+        </div>
+          </div>
+    -->
   </div> 
 </div>
   <footer>
-        <div class="back-to-top">
-            <a href="#hero"><i class="fas fa-chevron-up"></i></a>
-        </div>
+        
         <div class="footer-content" id="footer">
             <div class="footer-content-about animate-top">
                 <h4>About Us</h4>
@@ -266,27 +287,7 @@
                 </div>
             </div>
         </div>
-        <div class="profile-card col-lg-4 col-md-6 col-sm-12">
-          <a href="https://www.db-book.com/db4/slide-dir/ch1-2.pdf">
-              <div class="card-header" style="background:url(images/databasemgmnt.png) no-repeat center;object-fit: cover;">
-                  <div class="name">Database Management</div>
-          </a>
-    
-    
-          </div>
-          <div class="card-footer">
-              <div class="numbers">
-                  <div class="item">
-                      <span>11</span> Course Length
-                  </div>
-                  <div class="border"></div>
-                  <div class="item">
-                      <span>Beginner</span> Level
-                  </div>
-              </div>
-          </div>
-      </div>
-    </div>
+
     
         <div class="copyright animate-bottom">
             <h4>&copy; Copyright 2020 Project Basil, All Rights Reserved</h4>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
                     <a href="#topics" class="navlink">Topics</a>
                 </li>
                 <li class="navitem">
-                    <a href="#footer" class="navlink">Contact</a>
+                    <a href="#footer" class="navlink">Contac</a>
                 </li>
             </ul>
         </nav>
@@ -63,11 +63,13 @@
 <!--row1-->
 <!--1st box-->
 <div class="container-fluid" id="topics">
-<div class="row">
+<div class="row  justify-content-around">
   <div class="col-lg-4 col-md-6 col-sm-12">
     <div class="profile-card">
       <div class="card-header" id="one" >
+        <div class="overlay">
         <div class="name">Artificial Intelligence</div>
+      </div>
       </div>
       <div class="card-footer">
         <div class="numbers">
@@ -89,7 +91,9 @@
   <div class="profile-card">
     <a href="Course/ml/ml.html">
     <div class="card-header"  id="two" >
+      <div class="overlay">
       <div class="name">Machine Learning</div>
+    </div>
     </div>
   </a>
     <div class="card-footer">
@@ -111,7 +115,9 @@
 <div class="col-lg-4 col-md-6 col-sm-12">
   <div class="profile-card">
     <div class="card-header" id="three">
-      <div class="name">App Development</div>  
+      <div class="overlay">
+        <div class="name">App Development</div>  
+    </div>
     </div>
     <div class="card-footer">
       <div class="numbers">
@@ -134,12 +140,14 @@
 <!--2nd row-->
 <!--1st box-->
 <div class="container-fluid">
-  <div class="row">
+  <div class="row justify-content-around">
     <div class="col-lg-4 col-md-6 col-sm-12">
       <div class="profile-card">
         <a href="Course/index.html">
           <div class="card-header" id="four" >
-            <div class="name">Web Development</div>
+            <div class="overlay">
+              <div class="name">Web Development</div>
+          </div>
           </div>
         </a>
         <div class="card-footer">
@@ -161,7 +169,9 @@
   <div class="col-lg-4 col-md-6 col-sm-12">
     <div class="profile-card">
       <div class="card-header" id ="five" >
-        <div class="name">Cyber Security</div>
+        <div class="overlay">
+          <div class="name">Cyber Security</div>
+      </div>
       </div>
       <div class="card-footer">
         <div class="numbers">
@@ -183,7 +193,9 @@
   <div class="col-lg-4 col-md-6 col-sm-12">
     <div class="profile-card">
       <div class="card-header" id="six" >
-        <div class="name">Competitive Coding</div>  
+        <div class="overlay">
+          <div class="name">Competitive Coding</div>  
+        </div>
       </div>
       <div class="card-footer">
         <div class="numbers">
@@ -254,10 +266,9 @@
                 </div>
             </div>
         </div>
-        <div class="profile-card">
+        <div class="profile-card col-lg-4 col-md-6 col-sm-12">
           <a href="https://www.db-book.com/db4/slide-dir/ch1-2.pdf">
               <div class="card-header" style="background:url(images/databasemgmnt.png) no-repeat center;object-fit: cover;">
-                  
                   <div class="name">Database Management</div>
           </a>
     


### PR DESCRIPTION
Linked to issue #4 

**Previous**
<img width="1280" alt="Screenshot 2020-10-15 at 9 40 57 PM" src="https://user-images.githubusercontent.com/48119998/96333894-3e89e100-109f-11eb-99ba-075b598ce731.png">

**New**
<img width="1280" alt="Screenshot 2020-10-17 at 5 34 55 PM" src="https://user-images.githubusercontent.com/48119998/96333900-447fc200-109f-11eb-80d3-4e1a9ef78034.png">

**Changes**
- Fixed margin errors where topics where being cut off by the screen.
- Topic headers now blur and have a slightly-transparent black overlay that is removed when hovered
- Gave the topic footers a different colour to appeal to the purple theme
- Gave background a light purple theme
- Moved the back-to-top button to a fixed position on the bottom right (this feels like a more accessible place to put it)

**To note**
- Database management topic was in the footer, and I moved it to the topics section and commented it out
- The background image for competitive coding becomes hard-to-see due to the overlay, maybe change to an image with higher contrast or adjust the overlay blur and opacity values
